### PR TITLE
Run build process with configuration error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "builds": [
     {
-      "src": "vite.config.ts",
+      "src": "package.json",
       "use": "@vercel/static-build",
       "config": {
         "distDir": "dist"


### PR DESCRIPTION
Update Vercel build configuration to use `package.json` as the source, resolving build errors.