### PR TITLE
Troubleshoot API deployment issue

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -15,6 +15,9 @@ server.use(middlewares)
 server.use(router)
 
 export default function handler(req, res) {
-  // Delegate to JSON-Server Express app
+  // Remove the `/api` prefix that Vercel adds so json-server routes match (e.g., /employees)
+  if (req.url.startsWith('/api')) {
+    req.url = req.url.replace(/^\/api/, '') || '/'
+  }
   return server(req, res)
 }

--- a/vercel.json
+++ b/vercel.json
@@ -28,5 +28,10 @@
   ],
   "devCommand": "npm run dev",
   "buildCommand": "npm run build",
-  "outputDirectory": "dist"
+  "outputDirectory": "dist",
+  "functions": {
+    "api/index.js": {
+      "includeFiles": ["db.json"]
+    }
+  }
 }


### PR DESCRIPTION
Fix API 404 errors on Vercel by stripping `/api` prefix from requests and bundling `db.json`.

The `json-server` running within the Vercel serverless function expects routes like `/employees`. However, Vercel routes requests to `/api/employees`. This PR modifies the handler to strip the `/api` prefix, allowing `json-server` to correctly match routes. It also ensures `db.json` is included in the serverless function bundle, which was missing.