### PR TITLE
Fix vercel.json schema validation error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,10 @@
     },
     {
       "src": "api/index.js",
-      "use": "@vercel/node"
+      "use": "@vercel/node",
+      "config": {
+        "includeFiles": "db.json"
+      }
     }
   ],
   "routes": [
@@ -28,10 +31,5 @@
   ],
   "devCommand": "npm run dev",
   "buildCommand": "npm run build",
-  "outputDirectory": "dist",
-  "functions": {
-    "api/index.js": {
-      "includeFiles": "db.json"
-    }
-  }
+  "outputDirectory": "dist"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -31,7 +31,7 @@
   "outputDirectory": "dist",
   "functions": {
     "api/index.js": {
-      "includeFiles": ["db.json"]
+      "includeFiles": "db.json"
     }
   }
 }


### PR DESCRIPTION
Fix Vercel deployment error by changing `includeFiles` to a string in `vercel.json`.