### PR TITLE
Corrigir seleção do switch de linguagem

### DIFF
--- a/src/app/components/LanguageSwitcher.tsx
+++ b/src/app/components/LanguageSwitcher.tsx
@@ -8,9 +8,12 @@ export function LanguageSwitcher() {
     i18n.changeLanguage(value)
   }
 
+  // Normalise the detected language to its base code (e.g. "pt-BR" -> "pt") so
+  // it matches one of the SegmentedControl options below. Otherwise nothing
+  // appears selected on first load.
   return (
     <SegmentedControl
-      value={i18n.language}
+      value={i18n.language.split('-')[0]}
       onChange={onLanguageChange}
       data={[
         { label: 'PT', value: 'pt' },


### PR DESCRIPTION
Normalize language code in `LanguageSwitcher` to correctly display selected language on initial load.

The `LanguageSwitcher` component's `SegmentedControl` was directly receiving `i18n.language`. When the detected locale included a region suffix (e.g., "pt-BR", "en-US"), it didn't match the available options ("pt", "en"), causing no option to be selected on first load. This PR normalizes the language by taking only the base code (e.g., `i18n.language.split('-')[0]`) before passing it to the control, ensuring the correct language is always displayed upon app load.